### PR TITLE
fix(config): 🐛 revert version to 1.0.0 for initial release [skip release]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-smart-test"
-version = "1.1.0"
+version = "1.0.0"
 description = "Development, testing, and dependency analysis tools for Python projects."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Revert version from 1.1.0 back to 1.0.0. The release workflow incorrectly bumped the version before the first release was published.