### PR TITLE
feat(ci): ✨ add publish-only mode to release workflow [skip release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ on:
                 description: "Force release even if no changes detected"
                 type: boolean
                 default: false
+            publish_only:
+                description: "Publish current version to PyPI without version bump"
+                type: boolean
+                default: false
 
 permissions:
     contents: write
@@ -46,10 +50,65 @@ env:
     PYTHONPATH: src
 
 jobs:
+    publish:
+        name: Publish to PyPI
+        runs-on: ubuntu-latest
+        if: ${{ github.event.inputs.publish_only == 'true' }}
+        environment:
+            name: pypi
+            url: https://pypi.org/p/py-smart-test
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  enable-cache: true
+
+            - name: Set up Python
+              run: uv python install
+
+            - name: Build package
+              run: |
+                  VERSION=$(uv version | awk '{print $2}')
+                  echo "📦 Building v$VERSION..."
+                  rm -rf dist/
+                  uv build --no-sources
+                  ls -la dist/
+                  echo "✅ Build completed"
+
+            - name: Publish to PyPI
+              env:
+                  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+              run: |
+                  VERSION=$(uv version | awk '{print $2}')
+                  echo "🚀 Publishing v$VERSION to PyPI..."
+
+                  if uv publish; then
+                    echo "🎉 Published using trusted publishing"
+                  elif [ -n "$PYPI_TOKEN" ]; then
+                    echo "🔑 Fallback to token authentication..."
+                    export UV_PUBLISH_TOKEN="$PYPI_TOKEN"
+                    uv publish
+                    echo "🎉 Published using token authentication"
+                  else
+                    echo "❌ Publication failed"
+                    exit 1
+                  fi
+
+            - name: Summary
+              run: |
+                  VERSION=$(uv version | awk '{print $2}')
+                  echo "# 🚀 Published to PyPI" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Version**: v$VERSION" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Package**: [py-smart-test](https://pypi.org/project/py-smart-test/$VERSION/)" >> $GITHUB_STEP_SUMMARY
+
     release:
         name: Release and Publish
         runs-on: ubuntu-latest
-        if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
+        if: ${{ github.event.inputs.publish_only != 'true' && !contains(github.event.head_commit.message, '[skip release]') }}
         outputs:
             should_release: ${{ steps.version-analysis.outputs.should_release }}
             new_version: ${{ steps.bump-version.outputs.new_version }}


### PR DESCRIPTION
Add a `publish_only` option to the release workflow that builds and publishes the current version to PyPI without version bumping, PR creation, or tagging. Supports trusted publishing and token fallback.