### PR TITLE
fix(core): 🐛 auto-discover project layout for cross-project usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ choices = [
     { value = "build", name = "🏗️ build: Changes that affect the build system or external dependencies" },
     { value = "ci", name = "👷 ci: Changes to CI configuration files and scripts" },
     { value = "chore", name = "🔧 chore: Other changes that don't modify src or test files" },
-    { value = "revert", name = "⏪ revert: Revert to a commit" }
+    { value = "revert", name = "⏪ revert: Revert to a commit" },
 ]
 
 [[tool.commitizen.customize.questions]]
@@ -90,7 +90,7 @@ choices = [
     { value = "test", name = "test: Testing functionality and test runner" },
     { value = "config", name = "config: Configuration and setup files" },
     { value = "ci", name = "ci: CI/CD and development tooling" },
-    { value = "docs", name = "docs: Documentation and README" }
+    { value = "docs", name = "docs: Documentation and README" },
 ]
 
 [[tool.commitizen.customize.questions]]

--- a/src/py_smart_test/_paths.py
+++ b/src/py_smart_test/_paths.py
@@ -1,28 +1,135 @@
-"""Path constants for dependency graph system."""
+"""Path constants for dependency graph system.
 
+Automatically discovers the project layout by scanning the current working
+directory for source packages and reading optional configuration from
+pyproject.toml ``[tool.py-smart-test]``.
+
+Supported configuration keys in ``[tool.py-smart-test]``::
+
+    src_dir = "src"              # Source directory (default: auto-detected)
+    packages = ["my_package"]    # Package names (default: auto-discovered)
+    test_dir = "tests"           # Test directory (default: "tests")
+    default_branch = "main"      # Git base branch (default: auto-detected)
+"""
+
+import subprocess
+import tomllib
 from pathlib import Path
+from typing import List
 
-# Get repo root (Use current working directory as project root)
+
+def _load_config(repo_root: Path) -> dict:
+    """Load py-smart-test config from pyproject.toml [tool.py-smart-test]."""
+    pyproject = repo_root / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            return data.get("tool", {}).get("py-smart-test", {})
+        except Exception:
+            return {}
+    return {}
+
+
+def _discover_src_dir(repo_root: Path, config: dict) -> Path:
+    """Discover the source directory containing Python packages."""
+    if "src_dir" in config:
+        return repo_root / config["src_dir"]
+
+    # Standard src layout
+    src = repo_root / "src"
+    if src.is_dir():
+        return src
+
+    # Flat layout (source in repo root)
+    return repo_root
+
+
+def _discover_packages(src_dir: Path, config: dict) -> List[str]:
+    """Discover Python packages under the source directory."""
+    if "packages" in config:
+        return config["packages"]
+
+    packages = []
+    if src_dir.is_dir():
+        for item in sorted(src_dir.iterdir()):
+            if (
+                item.is_dir()
+                and (item / "__init__.py").exists()
+                and not item.name.startswith((".", "_"))
+            ):
+                packages.append(item.name)
+    return packages
+
+
+def _discover_test_dir(repo_root: Path, config: dict) -> Path:
+    """Discover the test directory."""
+    if "test_dir" in config:
+        return repo_root / config["test_dir"]
+    return repo_root / "tests"
+
+
+def _discover_default_branch(repo_root: Path, config: dict) -> str:
+    """Auto-detect the git default branch."""
+    if "default_branch" in config:
+        return config["default_branch"]
+
+    # Try git symbolic-ref (works when remote is configured)
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=repo_root,
+        )
+        return result.stdout.strip().split("/")[-1]
+    except Exception:
+        pass
+
+    # Try common branch names
+    for branch in ["main", "master", "develop"]:
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--verify", branch],
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=repo_root,
+            )
+            return branch
+        except Exception:
+            continue
+
+    return "main"
+
+
+# ── Project root ──────────────────────────────────────────────────────
 REPO_ROOT = Path.cwd()
 
-# Dependency graph locations (in main project)
+# ── Configuration ─────────────────────────────────────────────────────
+_CONFIG = _load_config(REPO_ROOT)
+
+# ── Source layout ─────────────────────────────────────────────────────
+SRC_ROOT = _discover_src_dir(REPO_ROOT, _CONFIG)
+PACKAGES = _discover_packages(SRC_ROOT, _CONFIG)
+TEST_ROOT = _discover_test_dir(REPO_ROOT, _CONFIG)
+DEFAULT_BRANCH = _discover_default_branch(REPO_ROOT, _CONFIG)
+
+# ── Dependency graph locations ────────────────────────────────────────
 PY_SMART_TEST_DIR = REPO_ROOT / ".py_smart_test"
 GRAPH_DIR = PY_SMART_TEST_DIR
 GRAPH_FILE = GRAPH_DIR / "dependency_graph.json"
 CACHE_DIR = GRAPH_DIR / "cache"
 CACHE_FILE = CACHE_DIR / "dependency_graph_cache.json"
 
-# Application directories (in main project)
-SRC_ROOT = REPO_ROOT / "src" / "py_smart_test"
-TEST_ROOT = REPO_ROOT / "tests"
-
-# Ensure directories exist
+# ── Ensure directories exist ─────────────────────────────────────────
 GRAPH_DIR.mkdir(parents=True, exist_ok=True)
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 LOGS_DIR = PY_SMART_TEST_DIR / "logs"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
-# Ensure .gitignore exists for generated files
+# ── Auto-generate .gitignore for generated files ─────────────────────
 GITIGNORE_FILE = PY_SMART_TEST_DIR / ".gitignore"
 if not GITIGNORE_FILE.exists():
     GITIGNORE_FILE.write_text(

--- a/src/py_smart_test/find_affected_modules.py
+++ b/src/py_smart_test/find_affected_modules.py
@@ -85,7 +85,7 @@ def get_affected_tests(
     affected_modules = set()
     direct_test_files = set()
 
-    src_root = _paths.SRC_ROOT.parent
+    src_root = _paths.SRC_ROOT
     valid_modules = set(graph["modules"].keys())
 
     for file_path in changed_files:
@@ -145,7 +145,7 @@ def get_affected_tests(
 
 @app.command()
 def main(
-    base: str = typer.Option("main", help="Git base reference"),
+    base: str = typer.Option(_paths.DEFAULT_BRANCH, help="Git base reference"),
     staged: bool = typer.Option(False, help="Check staged changes only"),
     json_output: bool = typer.Option(False, "--json", help="Output in JSON format"),
 ):

--- a/src/py_smart_test/smart_test_runner.py
+++ b/src/py_smart_test/smart_test_runner.py
@@ -81,7 +81,9 @@ def run_pytest(tests: List[str], extra_args: List[str]):
 @app.command()
 def main(
     mode: str = typer.Option("affected", help="Mode: 'affected' or 'all'"),
-    since: str = typer.Option("main", help="Git base reference for changes"),
+    since: str = typer.Option(
+        _paths.DEFAULT_BRANCH, help="Git base reference for changes"
+    ),
     staged: bool = typer.Option(False, help="Check staged changes only"),
     regenerate_graph: bool = typer.Option(
         False, help="Force regenerate dependency graph"

--- a/src/py_smart_test/test_module_mapper.py
+++ b/src/py_smart_test/test_module_mapper.py
@@ -63,10 +63,11 @@ def map_tests_to_modules(test_root: Path) -> Dict[str, List[str]]:
         if candidate_suffix in valid_modules:
             matches.append(candidate_suffix)
 
-        # Prefix match
-        prefixed = f"py_smart_test.{candidate_suffix}"
-        if prefixed in valid_modules:
-            matches.append(prefixed)
+        # Prefix match: try each discovered package name
+        for pkg in _paths.PACKAGES:
+            prefixed = f"{pkg}.{candidate_suffix}"
+            if prefixed in valid_modules:
+                matches.append(prefixed)
 
         if matches:
             for m in matches:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,9 @@ def mock_paths(monkeypatch, temp_repo_root):
     from py_smart_test import _paths
 
     monkeypatch.setattr(_paths, "REPO_ROOT", temp_repo_root)
-    monkeypatch.setattr(_paths, "SRC_ROOT", temp_repo_root / "src" / "py_smart_test")
+    monkeypatch.setattr(_paths, "SRC_ROOT", temp_repo_root / "src")
+    monkeypatch.setattr(_paths, "PACKAGES", ["py_smart_test"])
+    monkeypatch.setattr(_paths, "DEFAULT_BRANCH", "main")
     monkeypatch.setattr(_paths, "TEST_ROOT", temp_repo_root / "tests")
     monkeypatch.setattr(_paths, "GRAPH_DIR", temp_repo_root / ".py_smart_test")
     monkeypatch.setattr(

--- a/tests/test_generate_dependency_graph.py
+++ b/tests/test_generate_dependency_graph.py
@@ -45,7 +45,7 @@ def test_syntax_error_handling(temp_repo_root, monkeypatch, mock_paths):
     bad_file = temp_repo_root / "src" / "py_smart_test" / "bad.py"
     bad_file.write_text("def broken(")
 
-    scan_and_build_graph(temp_repo_root / "src" / "py_smart_test")
+    scan_and_build_graph(temp_repo_root / "src")
 
     assert any("Syntax error" in str(c) for c in mock_logger.warning.call_args_list)
 
@@ -74,26 +74,24 @@ def test_resolve_relative_too_deep():
 
 
 def test_scan_and_build_graph(temp_repo_root, mock_paths):
-    src = mock_paths.SRC_ROOT
-    # src is .../src/py_smart_test
-    # But scan_and_build_graph uses src.parent (.../src) as root
-    # So we should create files matching 'py_smart_test' package structure
+    # SRC_ROOT is now src/, package is under src/py_smart_test/
+    pkg = temp_repo_root / "src" / "py_smart_test"
 
     # Ensure package init
-    (src / "__init__.py").touch()
+    (pkg / "__init__.py").touch()
 
     # core/base.py
-    (src / "core").mkdir()
-    (src / "core" / "__init__.py").touch()
-    base_py = src / "core" / "base.py"
+    (pkg / "core").mkdir()
+    (pkg / "core" / "__init__.py").touch()
+    base_py = pkg / "core" / "base.py"
     base_py.write_text("import os\nclass Base: pass")
 
     # core/utils.py
-    utils_py = src / "core" / "utils.py"
+    utils_py = pkg / "core" / "utils.py"
     utils_py.write_text("from .base import Base\nimport json")
 
     # main.py
-    main_py = src / "main.py"
+    main_py = pkg / "main.py"
     main_py.write_text("from py_smart_test.core.utils import Base\nimport sys")
 
     # Run scan


### PR DESCRIPTION
## Summary

Fixes runtime failures when `pst`/`pst-gen` are installed as a dev dependency in external projects.

### Root Cause
`_paths.py` hardcoded `py_smart_test` as the package name in `SRC_ROOT`, causing the tool to scan for `{project}/src/py_smart_test/` instead of the target project's actual packages.

### Changes
- **`_paths.py`**: Complete rewrite with auto-discovery architecture
  - `_discover_src_dir()`: finds `src/` or flat layout
  - `_discover_packages()`: scans for dirs with `__init__.py`
  - `_discover_default_branch()`: git symbolic-ref → rev-parse fallback
  - `_load_config()`: reads `[tool.py-smart-test]` from `pyproject.toml`
  - New exports: `SRC_ROOT` (now `src/`, not `src/package/`), `PACKAGES`, `DEFAULT_BRANCH`
- **`generate_dependency_graph.py`**: Use `src_root` param directly; fix cross-platform file paths
- **`find_affected_modules.py`**: Use `_paths.SRC_ROOT` directly; auto-detect default branch
- **`smart_test_runner.py`**: Use `DEFAULT_BRANCH` for `--since` default
- **`test_module_mapper.py`**: Loop `_paths.PACKAGES` instead of hardcoded prefix
- **Tests**: Updated conftest and test files for new `SRC_ROOT` semantics

### Testing
- All 59 tests pass locally
- All 15 pre-commit hooks pass